### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@ The first step to create an Automatic Spoken Language Assessment system (Prosody
 The code reads speech data from an audio file and measures prosody, pronunciation and structure. It was architected and assembled in PRAAT. 
 It created a real-time and comprehensive performance report. 
 The analytical module o the code is pure mathematics and statistics FOR the BASIC VERO
+
+# Branch 1 Verion 
+
+License: APA 2.02 UKREF
+
+The scientific way to measure one’s Reading/Speaking rate is in syllables per second.
+
+OSP’s estimate of the “Reading Rate” is obtained by timing the user while reading a selection of text with a known syllables count.
+
+OSP evaluates the competency of the user by employing mathematical formulas and ETS’s independent speaking rubrics and philosophy (Educational Testing Service-USA).
+
+OSP went through a Machine learning session, with an audio dataset of non-native and native English speakers. These audios ranged from just 2 minutes in length to just under 5 minutes. Speakers' topics were widely variable.


### PR DESCRIPTION
The scientific way to measure one’s Reading/Speaking rate is in syllables per second.

OSP’s estimate of the “Reading Rate” is obtained by timing the user while reading a selection of text with a known syllables count.

OSP evaluates the competency of the user by employing mathematical formulas and ETS’s independent speaking rubrics and philosophy (Educational Testing Service-USA).

OSP went through a Machine learning session, with an audio dataset of non-native and native English speakers. These audios ranged from just 2 minutes in length to just under 5 minutes. Speakers' topics were widely variable.